### PR TITLE
Upgrade from curation_concerns to hyrax

### DIFF
--- a/.fcrepo_wrapper.development.yml
+++ b/.fcrepo_wrapper.development.yml
@@ -1,5 +1,6 @@
 # Default configuration for fcrepo_wrapper in development environment
 port: 8984
 enable_jms: false
+version: 4.7.0
 fcrepo_home_dir: tmp/fcrepo4-development-data
 verbose: true

--- a/.fcrepo_wrapper.test.yml
+++ b/.fcrepo_wrapper.test.yml
@@ -1,4 +1,5 @@
 # Default configuration for fcrepo_wrapper in test environment
 port: 8986
 enable_jms: false
+version: 4.7.0
 fcrepo_home_dir: tmp/fcrepo4-test-data

--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,11 @@ gemspec
 
 gem 'engine_cart'
 # BEGIN ENGINE_CART BLOCK
-# engine_cart: 1.0.1
+# engine_cart: 1.1.0
 # engine_cart stanza: 0.10.0
 # the below comes from engine_cart, a gem used to test this Rails engine gem in the context of a Rails app.
 file = File.expand_path('Gemfile', ENV['ENGINE_CART_DESTINATION'] || ENV['RAILS_ROOT'] || File.expand_path('.internal_test_app', File.dirname(__FILE__)))
+
 if File.exist?(file)
   begin
     eval_gemfile file
@@ -42,6 +43,9 @@ else
 end
 # END ENGINE_CART BLOCK
 
-
-# Local mods to Gemfile to pull in release candidate for CurationConcerns
-gem 'curation_concerns', github: 'projecthydra/curation_concerns', ref: 'v2.0.0.rc2'
+# Hyrax v1.0.0.rc1 is not available on rubygems.org yet, so need to pull from
+# Github.
+# NOTE: This needs to be copied to spec/test_app_templates/Gemfile.extra as
+# well in order for engine_cart to generate the test app with the correct
+# dependencies.
+gem 'hyrax', github: 'projecthydra-labs/hyrax', ref: 'v1.0.0.rc1'

--- a/app/presenters/preservation/event_index_presenter.rb
+++ b/app/presenters/preservation/event_index_presenter.rb
@@ -2,8 +2,8 @@ module Preservation
   class EventIndexPresenter < Blacklight::IndexPresenter
     # Returns the value of PremisEventType#label for the PremisEventType instance
     # whose #abbr value matches that which is in the solr document.
-    def label(field, opts = {})
-      premis_event_type = PremisEventType.all.find { |premis_event_type| premis_event_type.abbr == document.first(field) }
+    def search_result_title
+      premis_event_type = PremisEventType.all.find { |premis_event_type| premis_event_type.abbr == document.first(:premis_event_type_ssim) }
       premis_event_type.label
     end
   end

--- a/app/views/preservation/events/_index_header_list_default.html.erb
+++ b/app/views/preservation/events/_index_header_list_default.html.erb
@@ -1,0 +1,20 @@
+<%
+# NOTE: This overrides Hyrax's
+# app/views/catalog/_index_header_list_default.html.erb which (at the time of
+# this writing) only calls `document.title_or_label`, where `document` is a
+# `SolrDocument` instance. We need to use a presenter object, because we use a
+# small bit of logic to return the title of a search result. Hyrax will
+# probably be upgraded to use a presenter in it's own version of this view
+# partial in the near future, but until then, we override it here.
+
+# Furthermore, since we are using our own custom presenter, and our own custom
+# view partial, configuring the title field using `config.index.title_file` in
+# the EventsController's `configure_blacklight` block has no effect here. Instead,
+# we're just overriding the default index presenter, giving it a special
+# method, and calling that special method from this overridden partial.
+
+# Confused yet? Yeah, me too.
+%>
+  <h2>
+    <%= link_to index_presenter(document).search_result_title, document %>
+  </h2>

--- a/lib/generators/preservation/install_generator.rb
+++ b/lib/generators/preservation/install_generator.rb
@@ -4,12 +4,10 @@ module Preservation
     desc <<-EOS
       This generator makes the following changes to your application:
        1. Adds Preservation routes to your ./config/routes.rb
-
-      Thank you for Installing Blacklight.
     EOS
 
     # def inject_search_builder_behavior
-    #   inject_into_file 'app/models/search_builder.rb', after: "include CurationConcerns::SearchFilters\n" do
+    #   inject_into_file 'app/models/search_builder.rb', after: "include Hyrax::SearchFilters\n" do
     #     "\tinclude Hydradam::SearchBuilderBehavior\n"
     #   end
     # end

--- a/lib/preservation.rb
+++ b/lib/preservation.rb
@@ -1,6 +1,6 @@
 if defined? Rails
   require "preservation/engine"
-  require 'curation_concerns'
+  require 'hyrax'
 end
 
 module Preservation

--- a/lib/preservation/engine.rb
+++ b/lib/preservation/engine.rb
@@ -7,6 +7,7 @@ module Preservation
       #{config.root}/app/indexers
       #{config.root}/app/presenters
       #{config.root}/app/search_builders
+      #{config.root}/lib/preservation
     )
   end
 end

--- a/lib/preservation/search_state.rb
+++ b/lib/preservation/search_state.rb
@@ -1,0 +1,7 @@
+module Preservation
+  class SearchState < Hyrax::SearchState
+    def url_for_document(doc, options = {})
+      [preservation, doc]
+    end
+  end
+end

--- a/preservation.gemspec
+++ b/preservation.gemspec
@@ -24,8 +24,7 @@ Gem::Specification.new do |s|
     'lib/preservation/preservation_event_logger.rb'
   ]
 
-  s.add_dependency "rails", "~> 5.0.0", ">= 5.0.0.1"
-  s.add_dependency "curation_concerns"
+  s.add_dependency "hyrax"
   # TODO: We can remove the pinned jquery-ui-rails dep here after upgrading to
   # curation_concerns 1.7.0
   s.add_dependency "jquery-ui-rails", "~> 5.0.5"

--- a/spec/features/preservation/search_events_spec.rb
+++ b/spec/features/preservation/search_events_spec.rb
@@ -19,21 +19,26 @@ describe 'Preservation Events search results' do
     it 'displays the PREMIS event type label for the title' do
       # Make a regex that checks for any PREMIS event type label.
       regex = /(#{Preservation::PremisEventType.all.map(&:label).join('|')})/
-      expect(page).to have_css('h4.index_title a', text: regex)
+      expect(page).to have_css('div#search-results h2 a', text: regex)
     end
 
     it 'displays the PREMIS agent' do
-      # TODO: avoid using hardcoded dynamic solr suffix here
-      expect(page).to have_css('dt.blacklight-premis_agent_ssim', count: 10)
+      # TODO: Better tests for verifying display of search result fields.
+      expect(page).to have_css('div#search-results div.row table tr th span.attribute-label', text: "Agent", count: 10)
+      basic_email_regex = /.+@.+\..+/
+      expect(page).to have_css('div#search-results div.row table tr td', text: basic_email_regex, count: 10)
     end
 
     it 'displays the date of the event' do
-      # TODO: avoid using hardcoded dynamic solr suffix here
-      expect(page).to have_css('dt.blacklight-premis_event_date_time_dtsim', count: 10)
+      # TODO: Better tests for verifying display of search result fields.
+      expect(page).to have_css('div#search-results div.row table tr th span.attribute-label', text: "Date", count: 10)
+      expect(page).to have_css('div#search-results div.row table tr td', text: /\d{4}\-\d{2}\-\d{2}/, count: 10)
     end
 
     it 'displays a link to the file' do
-      expect(page).to have_link('Example File', count: 10)
+      # TODO: Better tests for verifying display of search result fields.
+      expect(page).to have_css('div#search-results div.row table tr th span.attribute-label', text: "File", count: 10)
+      expect(page).to have_css('div#search-results div.row table tr td a', text: /.+/, count: 10)
     end
 
     context 'filters' do
@@ -67,7 +72,7 @@ describe 'Preservation Events search results' do
       end
 
       records_within_date_range.each do |record|
-        expect(page).to have_selector('dd', text: record.premis_event_date_time.first.year)
+        expect(page).to have_selector('td', text: record.premis_event_date_time.first.year)
       end
     end
 
@@ -123,12 +128,12 @@ describe 'Preservation Events search results' do
           premis_event_type = Preservation::PremisEventType.all.find { |premis_event_type| premis_event_type.uri == record.premis_event_type.first.id }
           premis_event_type.label
         end
-        expect(page).to have_selector('h4.index_title a', text: expected_text)
+        expect(page).to have_selector('div#search-results h2 a', text: expected_text)
       end
 
       # And ensure that none of the non-selected PREMIS event types show up
       (all_premis_event_types - selected_premis_event_types).each do |unselected_premis_event_type|
-        expect(page).to_not have_selector('h4.index_title a', text: unselected_premis_event_type.label)
+        expect(page).to_not have_selector('div#search-results h2 a', text: unselected_premis_event_type.label)
       end
     end
 
@@ -170,7 +175,7 @@ describe 'Preservation Events search results' do
     end
 
     it 'limits the results to those that match the submitted filter value for PREMIS agent', :focus do
-      expect(page).to have_selector('dd', text: example_email, count: 2)
+      expect(page).to have_selector('td', text: example_email, count: 2)
     end
 
     it 'does not clobber other filters when a new value is submitted for PREMIS agent' do

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Local mods to Gemfile to pull in release candidate for Hyrax
+gem 'hyrax', github: 'projecthydra-labs/hyrax', ref: 'v1.0.0.rc1'

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -3,8 +3,8 @@ require 'rails/generators'
 class TestAppGenerator < Rails::Generators::Base
   source_root File.join(Preservation.root, "spec", "test_app_templates")
 
-  def install_curation_concerns
-    generate 'curation_concerns:install -f'
+  def install_hyrax
+    generate 'hyrax:install -f'
   end
 
   def install_engine


### PR DESCRIPTION
At this point, the version of Hyrax we want isn't on rubygems.org, so we need to
get it from Github. The way to do that using EngineCart is to put the specific
version in spec/test_app_templates/Gemfile.extra.