### PR TITLE
HDM-1260: Adds Outcome to Event Views

### DIFF
--- a/app/controllers/hyrax/preservation/events_controller.rb
+++ b/app/controllers/hyrax/preservation/events_controller.rb
@@ -23,6 +23,7 @@ module Hyrax
       helper_method :display_premis_agent
       helper_method :display_premis_event_date_time
       helper_method :display_related_file
+      helper_method :display_outcome
 
       # TODO: We used to include CurationConcerns::ApplicationControllerBehavior
       # here, but that module was merged into Sufia::Controller, which was later
@@ -58,12 +59,14 @@ module Hyrax
         config.add_index_field solr_name(:hasEventRelatedObject, :symbol), label: "File", helper_method: :display_related_file
         config.add_index_field solr_name(:premis_event_date_time, :stored_searchable, type: :date), label: "Date", helper_method: :display_premis_event_date_time
         config.add_index_field solr_name(:premis_agent, :symbol), label: "Agent", helper_method: :display_premis_agent
+        config.add_index_field solr_name(:premis_event_outcome, :stored_searchable), label: "Outcome", helper_method: :display_outcome
 
         # Show view config
         config.show.document_presenter_class = EventShowPresenter
         config.add_show_field solr_name(:premis_agent, :symbol), label: "PREMIS Agent"
         config.add_show_field solr_name(:premis_event_date_time, :stored_searchable, type: :date), label: "Date"
         config.add_show_field solr_name(:hasEventRelatedObject, :symbol), label: "File", helper_method: :display_related_file
+        config.add_show_field solr_name(:premis_event_outcome, :stored_searchable), label: "Outcome", helper_method: :display_outcome
 
         # Remove unused actions from the show view. Enabling these breaks the
         # show view because Blacklight generates urls that don't exist. Figuring
@@ -106,6 +109,11 @@ module Hyrax
         Date.parse(premis_event_date_time.to_s).strftime('%Y-%m-%d')
       end
 
+      def display_outcome(opts={})
+        solr_doc = opts[:document]
+        solr_doc[opts[:field]].first
+      end
+
       def display_related_file(opts={})
         # TODO: Is there a better way than having the controller send back HTML?
         # TODO: Is there a better way to fetch the FileSet ID and Title? This way is confusing.
@@ -125,7 +133,7 @@ module Hyrax
         # or the PreservationEventIndexer (in the hyrax-preservation gem) needs to have similar fallback logic
         # when indexing a representative name for the FileSet.
         file_set = ::FileSet.find(file_set_id)
-        file_set_title = file_set&.title&.first ||  file_set&.label || file_set&.filename&.first
+        file_set_title = file_set&.title&.first ||  file_set&.label || file_set&.file_name&.first
         "<a href='#{file_set_url}'>#{file_set_title}</a>".html_safe
       end
     end

--- a/spec/factories/hyrax/preservation/event.rb
+++ b/spec/factories/hyrax/preservation/event.rb
@@ -8,6 +8,8 @@ FactoryGirl.define do
     premis_event_type { [Hyrax::Preservation::PremisEventType.all.sample.uri] }
     premis_event_date_time { [DateTime.now - rand(30000).hours] }
     premis_event_related_object { create(:file_set) }
+    premis_event_outcome { ['173126004d5f1b13e41a9f3f53ca3d81'] }
+
     sequence(:premis_agent) { |n| [::RDF::URI.new("mailto:premis_agent_#{n}@hydradam.org")] }
 
     after :build do |event, evaluator|

--- a/spec/features/hyrax/preservation/search_events_spec.rb
+++ b/spec/features/hyrax/preservation/search_events_spec.rb
@@ -41,6 +41,11 @@ describe 'Preservation Events search results' do
       expect(page).to have_css('div#search-results div.row table tr td a', text: /.+/, count: 10)
     end
 
+    it 'displays the outcome' do
+      expect(page).to have_css('div#search-results div.row table tr th span.attribute-label', text: "Outcome", count: 10)
+      expect(page).to have_css('div#search-results div.row table tr td', text: '173126004d5f1b13e41a9f3f53ca3d81', count: 10)
+    end
+
     context 'filters' do
       it 'has a search filter for date' do
         expect(page).to have_css('form#date_time_range_filter')

--- a/spec/features/hyrax/preservation/show_event_spec.rb
+++ b/spec/features/hyrax/preservation/show_event_spec.rb
@@ -2,8 +2,10 @@ require 'rails_helper'
 
 describe 'Preservation Events details page' do
     let(:preservation_event) do
-      create(:event, premis_agent: [::RDF::URI.new("mailto:premis_agent@example.org")],
-                     premis_event_date_time: [DateTime.new(2014,1,16)])
+      create(:event,
+        premis_agent: [::RDF::URI.new("mailto:premis_agent@example.org")],
+        premis_event_date_time: [DateTime.new(2014,1,16)],
+        premis_event_outcome: ["173126004d5f1b13e41a9f3f53ca3d81"])
     end
     before { visit "preservation/events/#{preservation_event.id}" }
 
@@ -22,5 +24,9 @@ describe 'Preservation Events details page' do
 
     it 'displays the related file' do
       expect(page).to have_link('Example File')
+    end
+
+    it 'displays the outcome' do
+      expect(page).to have_text('173126004d5f1b13e41a9f3f53ca3d81')
     end
 end


### PR DESCRIPTION
This adds the outcome attribute to Event views from hyrax-preservation. In addition, it updates how we display the related file if it has a "file_name." Originally it was looking for "filename" which wasn't working in the WGBH fork of phydo. 